### PR TITLE
JSON output is the default output format.

### DIFF
--- a/btrfs-snapshots-diff.py
+++ b/btrfs-snapshots-diff.py
@@ -637,17 +637,13 @@ def main():
                 print(f'{sep}{k}={v}', end='')
             print()
 
-    elif args.json:
+    else:
+        # JSON format is default
         import json  # pylint: disable=import-outside-toplevel
         if args.pretty:
             print(json.dumps(commands, indent=2))
         else:
             print(json.dumps(commands))            
-
-    else:
-        printerr('No output!\n')
-        parser.print_help()
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Current behavior was printing an error if no output format is specified. However, both the error message was misleading ("No output!" means "There is no output to show") and unnecessary, because it won't break anything if we provide a default output format. 