### PR TITLE
feat: add --stats

### DIFF
--- a/btrfs-snapshots-diff.py
+++ b/btrfs-snapshots-diff.py
@@ -569,6 +569,9 @@ def main():
         '-j', '--json', action='store_true', help='JSON output (commands only)'
     )
     parser.add_argument(
+        '--stats', action='store_true', help='Print simple statistics'
+    )
+    parser.add_argument(
         '--pretty', action='store_true', help=argparse.SUPPRESS
     )
     parser.add_argument(
@@ -618,6 +621,14 @@ def main():
     if stream.version is None:
         exit(1)
     commands, paths = stream.decode(bogus=args.bogus)
+
+    if args.stats:
+        from collections import Counter
+
+        print('Commands:')
+        command_counts = Counter(list(map(lambda d: d["command"], commands)))
+        for key, count in command_counts.most_common():
+            print(f'{count}\t{key}')
 
     if args.by_path:
         print(f'Found a valid Btrfs stream header, version {stream.version}\n')

--- a/btrfs-snapshots-diff.py
+++ b/btrfs-snapshots-diff.py
@@ -630,6 +630,8 @@ def main():
         for key, count in command_counts.most_common():
             print(f'{count}\t{key}')
 
+        exit(0)
+
     if args.by_path:
         print(f'Found a valid Btrfs stream header, version {stream.version}\n')
         print_by_paths(paths, commands, args.filter, args.csv)

--- a/btrfs-snapshots-diff.py
+++ b/btrfs-snapshots-diff.py
@@ -626,7 +626,7 @@ def main():
         from collections import Counter
 
         print('Commands:')
-        command_counts = Counter(list(map(lambda d: d["command"], commands)))
+        command_counts = Counter(d["command"] for d in commands)
         for key, count in command_counts.most_common():
             print(f'{count}\t{key}')
 


### PR DESCRIPTION
looks like this:

```
$ sudo btrfs subvolume snapshot -r ~/d/ ~/d/.snapshots/two
$ sudo btrfs send --no-data -p ~/d/.snapshots/one/ /mnt/d/.snapshots/two/ > /tmp/diff_file
$ ./bin/btrfs-snapshots-diff-summary.py -f /tmp/diff_file --stats
Commands:
1790787	utimes
1546893	set_xattr
520245	unlink
497927	link
69900	update_extent
30723	rename
27325	chown
27325	chmod
22684	mkfile
8064	rmdir
4641	mkdir
8	remove_xattr
3	truncate
1	snapshot
1	end
```